### PR TITLE
Remove redundant empty if/else statement in NotificationActivity (#2953)

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/contributions/MainActivity.java
@@ -485,8 +485,6 @@ public class MainActivity extends AuthenticatedActivity implements FragmentManag
                         viewPager.setCurrentItem(CONTRIBUTIONS_TAB_POSITION);
 
                         // TODO: If contrib fragment is visible and location permission is not given, display permission request button
-                    } else {
-
                     }
                 }
                 return;

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -157,7 +157,6 @@ public class NotificationActivity extends NavigationBaseActivity {
                             no_notification.setVisibility(View.VISIBLE);
                         } else {
                             setAdapter(notificationList);
-                        } if (notificationMenuItem != null) {
                         }
                         progressBar.setVisibility(View.GONE);
                     }, throwable -> {


### PR DESCRIPTION
* Remove redundant empty if/else statement

This patch removes an empty if/else statement that has no effect on the execution flow of the program.

* Remove redundant empty if/else statement in MainActivity

This patch removes an empty if/else statement that has no effect on the execution flow of the program, which makes the code simpler.

**Description (required)**

Fixes #{GitHub issue number} {Github issue title}

What changes did you make and why?

**Tests performed (required)**

Tested {build variant, e.g. ProdDebug} on {name of device or emulator} with API level {API level}.

**Screenshots showing what changed (optional - for UI changes)**

Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
